### PR TITLE
Add a concept of ambigous KOD table

### DIFF
--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -201,6 +201,7 @@ class Database:
                     print("Record %d too short: -- %s" % (i+1, ashex(data)), file=stderr)
                 except Exception as e:
                     print("Record %d broken: ERROR '%s' -- %s" % (i+1, e, ashex(data)), file=stderr)
+            del data
 
     def enumerate_files(self, table):
         """

--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -172,7 +172,7 @@ class Database:
             dbdef = self.decode_db_definition(dbinfo[1:])
         except Exception as e:
             print("ERROR decoding db definition: %s" % e)
-            print("This could possibly mean that you need to try with the --strucrack option")
+            print("This could possibly mean that you need to try     crodump strucrack     to deduct the database key first")
             return
 
         for k, v in dbdef.items():

--- a/crodump/croconvert.py
+++ b/crodump/croconvert.py
@@ -59,6 +59,9 @@ def csv_output(kod, args):
 
                 filereferences.extend([field for field in record.fields if field.typ == 6])
 
+    if args.nofiles:
+        return
+
     # Write all files from the file table. This is useful for unreferenced files
     for table in db.enumerate_tables(files=True):
         filedir = "Files-" + table.abbrev
@@ -94,6 +97,7 @@ def main():
     parser.add_argument("--strucrack", action="store_true", help="infer the KOD sbox from CroStru.dat")
     parser.add_argument("--dbcrack", action="store_true", help="infer the KOD sbox from CroIndex.dat+CroBank.dat")
     parser.add_argument("--nokod", "-n", action="store_true", help="don't KOD decode")
+    parser.add_argument("--nofiles", "-F", action="store_true", help="don't export files with .csv export")
     parser.add_argument("dbdir", type=str)
     args = parser.parse_args()
 
@@ -104,25 +108,21 @@ def main():
         kod = crodump.koddecoder.new(list(unhex(args.kod)))
     elif args.nokod:
         kod = None
-    elif args.strucrack:
+    elif args.strucrack or args.dbcrack:
         class Cls: pass
         cargs = Cls()
         cargs.dbdir = args.dbdir
         cargs.sys = False
         cargs.silent = True
-        cracked = strucrack(None, cargs)
+        cargs.fix = []
+        cargs.color = False
+        cargs.width = 24
+        cargs.noninteractive = True
+        cracked = strucrack(None, cargs) if args.strucrack else dbcrack(None, cargs)
         if not cracked:
-            return
-        kod = crodump.koddecoder.new(cracked)
-    elif args.dbcrack:
-        class Cls: pass
-        cargs = Cls()
-        cargs.dbdir = args.dbdir
-        cargs.sys = False
-        cargs.silent = True
-        cracked = dbcrack(None, cargs)
-        if not cracked:
-            return
+            exit(
+            "Can't automatically crack the database password. Try using   crodump strucrack   and pass the database key (KOD) using --kod"
+            )
         kod = crodump.koddecoder.new(cracked)
     else:
         kod = crodump.koddecoder.new()

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -242,6 +242,8 @@ def strucrack(kod, args):
     # If the KOD is not completely resolved, show the missing mappings
     unset_count = KOD_CONFIDENCE.count(0)
     if unset_count > 0:
+        if args.noninteractive:
+            return
         if not args.silent:
             unset_entries = ", ".join(["%02x" % o for o, v in enumerate(KOD) if KOD_CONFIDENCE[o] == 0])
             unused_values = ", ".join(["%02x" % v for v in sorted(set(range(0,256)).difference(set(kod_set)))])
@@ -368,7 +370,7 @@ def main():
     p.add_argument("--silent", action="store_true", help="no output")
     p.add_argument("--color", action="store_true", help="force color output even on non-ttys")
     p.add_argument("--fix", "-f", action="append", dest="fix", help="force KOD entries after identification")
-    p.add_argument("--text", "-t", action="append", dest="text", help="add fixed to decoder box by providing whole strings for a position in a record")
+    p.add_argument("--text", "-t", action="append", dest="text", help="add fixed bytes to decoder box by providing whole strings for a position in a record")
     p.add_argument("--width", "-w", type=int, help="max number of decoded characters on screen", default=24)
 
     p.add_argument("dbdir", type=str)

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -116,7 +116,7 @@ def color_code(c, confidence, force):
         return "\033[32m" + c + "\033[0m"
     if confidence > 3:
         return "\033[93m" + c + "\033[0m"
-    return "\033[35m" + c + "\033[0m"
+    return "\033[94m" + c + "\033[0m"
 
 def strucrack(kod, args):
     """

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -173,7 +173,7 @@ def strucrack(kod, args):
 
         KOD[i] = (c + o) % 256
         KOD_CONFIDENCE[i] = 255
-        # print("%02x %02x %02x" % (c, i, o))
+        # print("%02x %02x %02x" % ((c + o) % 256, i, o))
 
     kod_set = set([v for o, v in enumerate(KOD) if KOD_CONFIDENCE[o] > 0])
     unset_entries = [o for o, v in enumerate(KOD) if KOD_CONFIDENCE[o] == 0]

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -420,6 +420,10 @@ def main():
         cargs.sys = False
         cargs.silent = True
         cargs.noninteractive = False
+        # add all keys we forgot to add
+        for k, v in args.__dict__.items():
+            if not cargs.__dict__.get(k):
+                cargs.__dict__.update({k: v})
         cracked = strucrack(None, cargs)
         if not cracked:
             return

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -257,7 +257,7 @@ def strucrack(kod, args):
         return [0 if KOD_CONFIDENCE[o] == 0 else _ for o, _ in enumerate(KOD)]
 
     if not args.silent:
-        print("Use the following database key to decrypt the database with crodump or croconvert with the -f option:")
+        print("Use the following database key to decrypt the database with crodump or croconvert with the --kod option:")
         print(tohex(bytes(KOD)))
 
     return KOD

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -257,6 +257,7 @@ def strucrack(kod, args):
         return [0 if KOD_CONFIDENCE[o] == 0 else _ for o, _ in enumerate(KOD)]
 
     if not args.silent:
+        print("Use the following database key to decrypt the database with crodump or croconvert with the -f option:")
         print(tohex(bytes(KOD)))
 
     return KOD

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -176,7 +176,7 @@ def strucrack(kod, args):
         # print("%02x %02x %02x" % ((c + o) % 256, i, o))
 
     # For chunks of text where record and offset is known, set the KOD
-    for fix in args.text:
+    for fix in args.text or []:
         record, line, offset, text = fix.split(':', 4)
         data = table.readrec(int(record)+1)
         dataoff = int(line) + int(offset)
@@ -393,7 +393,7 @@ def main():
     p.add_argument("--noninteractive", action="store_true", help="Stop if automatic cracking fails")
     p.add_argument("--color", action="store_true", help="force color output even on non-ttys")
     p.add_argument("--fix", "-f", action="append", dest="fix", help="force KOD entries after identification")
-    p.add_argument("--text", "-t", action="append", dest="text", help="add fixed bytes to decoder box by providing whole strings for a position in a record")
+    p.add_argument("--text", "-t", action="append", dest="text", help="add fixed bytes to decoder box by providing whole strings for a position in a record, format is record:line:offset:plaintext")
     p.add_argument("--width", "-w", type=int, help="max number of decoded characters on screen", default=24)
 
     p.add_argument("dbdir", type=str)

--- a/crodump/hexdump.py
+++ b/crodump/hexdump.py
@@ -22,6 +22,23 @@ def ashex(line):
     """
     return " ".join("%02x" % _ for _ in line)
 
+def asambigoushex(line):
+    """
+    convert an array to a list of 2-digit hex values with potentially unset values of -1
+    """
+    return "".join("%02x" % _ if _ >= 0 else "??" for _ in line)
+
+def as1251(b):
+    """
+    convert a unicode character to a CP-1251 byte
+    This will help parse cyrillic user entries from command line.
+    """
+    try:
+        c = str(b).encode("cp1251")
+        return bytes(c)
+    except:
+        pass
+    return bytes(".")
 
 def aschr(b):
     """
@@ -45,7 +62,7 @@ def asasc(line):
     """
     convert a CP-1251 encoded byte-array to a line of unicode characters.
     """
-    return "".join(aschr(_) for _ in line)
+    return "".join(aschr(_) if _ >= 0 else '?' for _ in line)
 
 
 def hexdump(ofs, data, args):

--- a/crodump/hexdump.py
+++ b/crodump/hexdump.py
@@ -22,11 +22,11 @@ def ashex(line):
     """
     return " ".join("%02x" % _ for _ in line)
 
-def asambigoushex(line):
+def asambigoushex(line, confidence):
     """
     convert an array to a list of 2-digit hex values with potentially unset values of -1
     """
-    return "".join("%02x" % _ if _ >= 0 else "??" for _ in line)
+    return "".join("%02x" % _ if confidence[o] > 0 else "??" for o, _ in enumerate(line))
 
 def as1251(b):
     """
@@ -58,12 +58,14 @@ def aschr(b):
     return "."
 
 
-def asasc(line):
+def asasc(line, confidence=None):
     """
     convert a CP-1251 encoded byte-array to a line of unicode characters.
     """
-    return "".join(aschr(_) if _ >= 0 else '?' for _ in line)
-
+    if confidence == None:
+        return "".join(aschr(_) for _ in line)
+    else:
+        return "".join(aschr(_) if confidence[o] > 0 else "?" for o, _ in enumerate(line))
 
 def hexdump(ofs, data, args):
     """

--- a/crodump/koddecoder.py
+++ b/crodump/koddecoder.py
@@ -26,13 +26,14 @@ class KODcoding:
     class handing KOD encoding and decoding, optionally
     with a user specified KOD table.
     """
-    def __init__(self, initial=INITIAL_KOD):
+    def __init__(self, initial=INITIAL_KOD, confidence=[255] * 256):
         self.kod = [_ for _ in initial]
+        self.confidence = confidence
 
         # calculate the inverse table.
-        self.inv = [-1 for _ in initial]
+        self.inv = [0 for _ in initial]
         for i, x in enumerate(self.kod):
-            if x >= 0:
+            if confidence[i]:
                 self.inv[x] = i
 
     def decode(self, o, data):
@@ -47,7 +48,10 @@ class KODcoding:
         decode : shift, a[0]..a[n-1] -> b[0]..b[n-1]
             b[i] = KOD[a[i]]- (i+shift)
         """
-        return [(self.kod[b] - i - o) % 256 if self.kod[b] >= 0 else -1 for i, b in enumerate(data)]
+        return (
+            [(self.kod[b] - i - o) % 256 if self.confidence[b] > 0 else 0 for i, b in enumerate(data)],
+            [self.confidence[b] for b in data]
+        )
 
     def encode(self, o, data):
         """
@@ -63,5 +67,27 @@ def new(*args):
     """
     return KODcoding(*args)
 
+def match_with_mismatches(data, confidence, string, maxsubs=None):
+    """
+    find all occurences of string in data with at least one and allowing a
+    maximum of maxsubs substitutions
+    """
 
+    # default for maximum of substitutions is to have at least two matching chars
+    maxsubs = maxsubs if maxsubs is not None else max( 2, len(string) - 2)
 
+    # if string cant fit into data, return no matches
+    if len(string) > len(data):
+        return []
+
+    matches = []
+    for offs in range(0, len(data) - len(string)):
+        matching = 0
+        for o, c in enumerate(string):
+            if data[offs + o] == c and confidence[offs + o] > 0:
+                matching += 1
+
+        if matching != len(string) and matching >= maxsubs:
+            matches.append((offs, matching))
+
+    return sorted(matches, key=lambda x: x[1])

--- a/crodump/koddecoder.py
+++ b/crodump/koddecoder.py
@@ -30,9 +30,10 @@ class KODcoding:
         self.kod = [_ for _ in initial]
 
         # calculate the inverse table.
-        self.inv = [0 for _ in initial]
+        self.inv = [-1 for _ in initial]
         for i, x in enumerate(self.kod):
-            self.inv[x] = i
+            if x >= 0:
+                self.inv[x] = i
 
     def decode(self, o, data):
         """
@@ -40,6 +41,13 @@ class KODcoding:
             b[i] = KOD[a[i]]- (i+shift)
         """
         return bytes((self.kod[b] - i - o) % 256 for i, b in enumerate(data))
+
+    def try_decode(self, o, data):
+        """
+        decode : shift, a[0]..a[n-1] -> b[0]..b[n-1]
+            b[i] = KOD[a[i]]- (i+shift)
+        """
+        return [(self.kod[b] - i - o) % 256 if self.kod[b] >= 0 else -1 for i, b in enumerate(data)]
 
     def encode(self, o, data):
         """

--- a/crodump/koddecoder.py
+++ b/crodump/koddecoder.py
@@ -49,7 +49,7 @@ class KODcoding:
             b[i] = KOD[a[i]]- (i+shift)
         """
         return (
-            [(self.kod[b] - i - o) % 256 if self.confidence[b] > 0 else 0 for i, b in enumerate(data)],
+            [(self.kod[b] - i - o) % 256 if self.confidence[b] != 0 else 0 for i, b in enumerate(data)],
             [self.confidence[b] for b in data]
         )
 


### PR DESCRIPTION
If the cracking heuristics can not completely deduct a KOD table, allow for unresolved entries with the value of -1

To fix up some of these entries, the user can provide a new fix for the table via the -f option.

To further guide the user, print out preliminarily decoded struc records and some stats about duplicated and missing KOD mappings.