### PR TITLE
Reduce memory footprint

### DIFF
--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -31,9 +31,9 @@ class Database:
         self.kod = kod
 
         # Stru+Index+Bank for the components for most databases
-        self.bank = self.getfile("Bank")
         self.stru = self.getfile("Stru")
         self.index = self.getfile("Index")
+        self.bank = self.getfile("Bank")
 
         # the Sys file resides in the "Program Files\Cronos" directory, and
         # contains an index of all known databases.

--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -51,7 +51,7 @@ class Database:
             datname = self.getname(name, "dat")
             tadname = self.getname(name, "tad")
             if datname and tadname:
-                return Datafile(name, open(datname, "rb"), open(tadname, "rb"), self.kod, self.compact)
+                return Datafile(name, open(datname, "rb"), open(tadname, "rb"), self.compact, self.kod)
         except IOError:
             return
 

--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -39,9 +39,6 @@ class Database:
         # contains an index of all known databases.
         self.sys = self.getfile("Sys")
 
-    def nrofrecords(self):
-        return self.bank.nrofrecords
-
     def getfile(self, name):
         """
         Returns a Datafile object for `name`.
@@ -194,7 +191,7 @@ class Database:
             for rec in db.enumerate_records(tab):
                 print(sqlformatter(tab, rec))
         """
-        for i in range(self.nrofrecords()):
+        for i in range(self.bank.nrofrecords):
             data = self.bank.readrec(i + 1)
             if data and data[0] == table.tableid:
                 try:
@@ -209,7 +206,7 @@ class Database:
         Yield all file contents found in CroBank for `table`.
         This is most likely the table with id 0.
         """
-        for i in range(self.nrofrecords()):
+        for i in range(self.bank,nrofrecords):
             data = self.bank.readrec(i + 1)
             if data and data[0] == table.tableid:
                 yield i + 1, data[1:]

--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -206,7 +206,7 @@ class Database:
         Yield all file contents found in CroBank for `table`.
         This is most likely the table with id 0.
         """
-        for i in range(self.bank,nrofrecords):
+        for i in range(self.bank.nrofrecords):
             data = self.bank.readrec(i + 1)
             if data and data[0] == table.tableid:
                 yield i + 1, data[1:]

--- a/crodump/Database.py
+++ b/crodump/Database.py
@@ -19,26 +19,28 @@ if sys.version_info[0] == 2:
 class Database:
     """represent the entire database, consisting of Stru, Index and Bank files"""
 
-    def __init__(self, dbdir, kod=crodump.koddecoder.new()):
+    def __init__(self, dbdir, compact, kod=crodump.koddecoder.new()):
         """
         `dbdir` is the directory containing the Cro*.dat and Cro*.tad files.
+        `compact` if set, the .tad file is not cached in memory, making dumps 15 % slower
         `kod` is optionally a KOD coder object.
               by default the v3 KOD coding will be used.
         """
         self.dbdir = dbdir
+        self.compact = compact
         self.kod = kod
 
         # Stru+Index+Bank for the components for most databases
+        self.bank = self.getfile("Bank")
         self.stru = self.getfile("Stru")
         self.index = self.getfile("Index")
-        self.bank = self.getfile("Bank")
 
         # the Sys file resides in the "Program Files\Cronos" directory, and
         # contains an index of all known databases.
         self.sys = self.getfile("Sys")
 
     def nrofrecords(self):
-        return len(self.bank.tadidx)
+        return self.bank.nrofrecords
 
     def getfile(self, name):
         """
@@ -52,7 +54,7 @@ class Database:
             datname = self.getname(name, "dat")
             tadname = self.getname(name, "tad")
             if datname and tadname:
-                return Datafile(name, open(datname, "rb"), open(tadname, "rb"), self.kod)
+                return Datafile(name, open(datname, "rb"), open(tadname, "rb"), self.kod, self.compact)
         except IOError:
             return
 

--- a/crodump/Datafile.py
+++ b/crodump/Datafile.py
@@ -4,14 +4,14 @@ import zlib
 from .hexdump import tohex, toout
 import crodump.koddecoder
 
-
 class Datafile:
     """Represent a single .dat with it's .tad index file"""
 
-    def __init__(self, name, dat, tad, kod):
+    def __init__(self, name, dat, tad, kod, compact):
         self.name = name
         self.dat = dat
         self.tad = tad
+        self.compact = compact
 
         self.readdathdr()
         self.readtad()
@@ -86,20 +86,45 @@ class Datafile:
         else:
             raise Exception("unsupported .tad version")
 
-        indexdata = self.tad.read()
+        self.tadhdrlen = self.tad.tell()
+        self.tadentrysize = 16 if self.use64bit else 12
+        if self.compact:
+            self.tad.seek(0, io.SEEK_END)
+        else:
+            self.idxdata = self.tad.read()
+        self.tadsize = self.tad.tell() - self.tadhdrlen
+        self.nrofrecords = self.tadsize // self.tadentrysize
+        if self.tadsize % self.tadentrysize:
+            print("WARN: leftover data in .tad")
+
+    def tadidx(self, idx):
+        """
+        If we're not supposed to be more compact but slower, lookup from a cached .tad
+        """
+        if self.compact:
+            return self.tadidx_seek(idx)
+
         if self.use64bit:
             # 01.03 and 01.11 have 64 bit file offsets
-            self.tadidx = [ struct.unpack_from("<QLL", indexdata, 16 * _) for _ in range(len(indexdata) // 16) ]
-            if len(indexdata) % 16:
-                print("WARN: leftover data in .tad")
+            return struct.unpack_from("<QLL", self.idxdata, idx * self.tadentrysize)
         else:
             # 01.02  and 01.04  have 32 bit offsets.
-            self.tadidx = [ struct.unpack_from("<LLL", indexdata, 12 * _) for _ in range(len(indexdata) // 12) ]
-            if len(indexdata) % 12:
-                print("WARN: leftover data in .tad")
+           return struct.unpack_from("<LLL", self.idxdata, idx * self.tadentrysize)
 
-    def nrofrecords(self):
-        return len(self.tadidx)
+
+    def tadidx_seek(self, idx):
+        """
+            Memory saving version without caching the .tad
+        """
+        self.tad.seek(self.tadhdrlen + idx * self.tadentrysize)
+        idxdata = self.tad.read(self.tadentrysize)
+
+        if self.use64bit:
+            # 01.03 and 01.11 have 64 bit file offsets
+            return struct.unpack("<QLL", idxdata)
+        else:
+            # 01.02  and 01.04  have 32 bit offsets.
+           return struct.unpack("<LLL", idxdata)
 
     def readdata(self, ofs, size):
         """
@@ -114,7 +139,7 @@ class Datafile:
         """
         if idx == 0:
             raise Exception("recnum must be a positive number")
-        ofs, ln, chk = self.tadidx[idx - 1]
+        ofs, ln, chk = self.tadidx(idx - 1)
         if ln == 0xFFFFFFFF:
             # deleted record
             return
@@ -164,7 +189,7 @@ class Datafile:
         return encdat
 
     def enumrecords(self):
-        for i in range(len(self.tadidx)):
+        for i in range(self.nrofrecords):
             yield self.readrec(i+1)
 
     def enumunreferenced(self, ranges, filesize):
@@ -195,7 +220,8 @@ class Datafile:
 
         ranges = []  # keep track of used bytes in the .dat file.
 
-        for i, (ofs, ln, chk) in enumerate(self.tadidx):
+        for i in range(self.nrofrecords):
+            (ofs, ln, chk) = self.tadidx(i)
             idx = i + 1
             if args.maxrecs and i==args.maxrecs:
                 break

--- a/crodump/Datafile.py
+++ b/crodump/Datafile.py
@@ -7,7 +7,7 @@ import crodump.koddecoder
 class Datafile:
     """Represent a single .dat with it's .tad index file"""
 
-    def __init__(self, name, dat, tad, kod, compact):
+    def __init__(self, name, dat, tad, compact, kod):
         self.name = name
         self.dat = dat
         self.tad = tad

--- a/crodump/croconvert.py
+++ b/crodump/croconvert.py
@@ -91,7 +91,7 @@ def main():
     parser.add_argument("--delimiter", "-d", default=",", help="delimiter used in csv output")
     parser.add_argument("--outputdir", "-o", type=str, help="directory to create the dump in")
     parser.add_argument("--kod", type=str, help="specify custom KOD table")
-    parser.add_argument("--compact", action="store_true", help="save memory by not caching the index (increases convert time by ~15%)")
+    parser.add_argument("--compact", action="store_true", help="save memory by not caching the index, note: increases convert time by factor 1.15")
     parser.add_argument("--strucrack", action="store_true", help="infer the KOD sbox from CroStru.dat")
     parser.add_argument("--dbcrack", action="store_true", help="infer the KOD sbox from CroIndex.dat+CroBank.dat")
     parser.add_argument("--nokod", "-n", action="store_true", help="don't KOD decode")

--- a/crodump/croconvert.py
+++ b/crodump/croconvert.py
@@ -23,7 +23,7 @@ def template_convert(kod, args):
             "Fatal: Jinja templating engine not found. Install using pip install jinja2"
         )
 
-    db = Database(args.dbdir, kod)
+    db = Database(args.dbdir, args.compact, kod)
 
     template_dir = join(dirname(dirname(abspath(__file__))), "templates")
     j2_env = Environment(loader=FileSystemLoader(template_dir))
@@ -38,7 +38,7 @@ def safepathname(name):
 def csv_output(kod, args):
     """creates a directory with the current timestamp and in it a set of CSV or TSV
        files with all the tables found and an extra directory with all the files"""
-    db = Database(args.dbdir, kod)
+    db = Database(args.dbdir, args.compact, kod)
 
     mkdir(args.outputdir)
     chdir(args.outputdir)
@@ -91,6 +91,7 @@ def main():
     parser.add_argument("--delimiter", "-d", default=",", help="delimiter used in csv output")
     parser.add_argument("--outputdir", "-o", type=str, help="directory to create the dump in")
     parser.add_argument("--kod", type=str, help="specify custom KOD table")
+    parser.add_argument("--compact", action="store_true", help="save memory by not caching the index (increases convert time by ~15%)")
     parser.add_argument("--strucrack", action="store_true", help="infer the KOD sbox from CroStru.dat")
     parser.add_argument("--dbcrack", action="store_true", help="infer the KOD sbox from CroIndex.dat+CroBank.dat")
     parser.add_argument("--nokod", "-n", action="store_true", help="don't KOD decode")

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -188,7 +188,7 @@ def main():
     parser.add_argument("--strucrack", action="store_true", help="infer the KOD sbox from CroStru.dat")
     parser.add_argument("--dbcrack", action="store_true", help="infer the KOD sbox from CroBank.dat + CroIndex.dat")
     parser.add_argument("--nokod", "-n", action="store_true", help="don't KOD decode")
-    parser.add_argument("--compact", action="store_true", help="save memory by not caching the index (increases convert time by ~15%)")
+    parser.add_argument("--compact", action="store_true", help="save memory by not caching the index, note: increases convert time by factor 1.15")
 
     p = subparsers.add_parser("kodump", help="KOD/hex dumper")
     p.add_argument("--offset", "-o", type=str, default="0")

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -160,7 +160,7 @@ def dbcrack(kod, args):
         if not dbfile:
             print("no data file found in %s" % args.dbdir)
             return
-        for i in range(1, min(10000, dbfile.nrofrecords())):
+        for i in range(1, min(10000, dbfile.nrofrecords)):
             rec = dbfile.readrec(i)
             if rec and len(rec)>11:
                 xref[(i+3)%256][rec[3]] += 1

--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -51,13 +51,13 @@ def cro_dump(kod, args):
         # an arbitrarily large number.
         args.maxrecs = 0xFFFFFFFF
 
-    db = Database(args.dbdir, kod)
+    db = Database(args.dbdir, args.compact, kod)
     db.dump(args)
 
 
 def stru_dump(kod, args):
     """handle 'strudump' subcommand"""
-    db = Database(args.dbdir, kod)
+    db = Database(args.dbdir, args.compact, kod)
     db.strudump(args)
 
 
@@ -66,7 +66,7 @@ def sys_dump(kod, args):
     # an arbitrarily large number.
     args.maxrecs = 0xFFFFFFFF
 
-    db = Database(args.dbdir, kod)
+    db = Database(args.dbdir, args.compact, kod)
     if db.sys:
         db.sys.dump(args)
 
@@ -79,7 +79,7 @@ def rec_dump(kod, args):
         # an arbitrarily large number.
         args.maxrecs = 0xFFFFFFFF
 
-    db = Database(args.dbdir, kod)
+    db = Database(args.dbdir, args.compact, kod)
     db.recdump(args)
 
 
@@ -95,7 +95,7 @@ def destruct(kod, args):
 
     if args.type == 1:
         # create a dummy db object
-        db = Database(".")
+        db = Database(".", args.compact)
         db.dump_db_definition(args, data)
     elif args.type == 2:
         tbdef = TableDefinition(data)
@@ -112,7 +112,7 @@ def strucrack(kod, args):
     """
 
     # start without 'KOD' table, so we will get the encrypted records
-    db = Database(args.dbdir, None)
+    db = Database(args.dbdir, args.compact, None)
     if args.sys:
         table = db.sys
         if not db.sys:
@@ -153,7 +153,7 @@ def dbcrack(kod, args):
 
     """
     # start without 'KOD' table, so we will get the encrypted records
-    db = Database(args.dbdir, None)
+    db = Database(args.dbdir, args.compact, None)
     xref = [ [0]*256 for _ in range(256) ]
 
     for dbfile in db.bank, db.index:
@@ -188,6 +188,7 @@ def main():
     parser.add_argument("--strucrack", action="store_true", help="infer the KOD sbox from CroStru.dat")
     parser.add_argument("--dbcrack", action="store_true", help="infer the KOD sbox from CroBank.dat + CroIndex.dat")
     parser.add_argument("--nokod", "-n", action="store_true", help="don't KOD decode")
+    parser.add_argument("--compact", action="store_true", help="save memory by not caching the index (increases convert time by ~15%)")
 
     p = subparsers.add_parser("kodump", help="KOD/hex dumper")
     p.add_argument("--offset", "-o", type=str, default="0")

--- a/crodump/dumpdbfields.py
+++ b/crodump/dumpdbfields.py
@@ -68,7 +68,7 @@ def main():
             db = Database(path, kod)
             for tab in db.enumerate_tables():
                 tab.dump(args)
-                print("nr of records: %d" % db.nrofrecords())
+                print("nr of records: %d" % db.bank.nrofrecords)
                 i = 0
                 for rec in db.enumerate_records(tab):
                     for field, fielddef in zip(rec.fields, tab.fields):


### PR DESCRIPTION
This PR makes the Datafile abstraction not cache the index entries in the .tad file anymore, greatly reducing the tool's memory footprint.

It also adds the `--compact` option to not cache the .tad file's content at all, but to seek() in the file for the entries each time.