### PR TITLE
Fix "AttributeError: 'Cls' object has no attribute" for "Add a concept of ambigous KOD table" pull

### DIFF
--- a/crodump/crodump.py
+++ b/crodump/crodump.py
@@ -420,6 +420,10 @@ def main():
         cargs.sys = False
         cargs.silent = True
         cargs.noninteractive = False
+        # add all keys we forgot to add
+        for k, v in args.__dict__.items():
+            if not cargs.__dict__.get(k):
+                cargs.__dict__.update({k: v})
         cracked = strucrack(None, cargs)
         if not cracked:
             return


### PR DESCRIPTION
Fix `AttributeError: 'Cls' object has no attribute`

Particularly in this case we need to add :

```python
        cargs.compact = args.compact
        cargs.text = args.text
        cargs.color = args.color
        cargs.width = args.width
```

But better add all in auto mode, IMHO

Ii do not know, should it be in dbcrack part or not, because those options are not set in relevant arg subparser, but without them dbcrack will also not work